### PR TITLE
NeoSpeech MRCPv1 compatability fix: send explicit ANNOUNCE:STOP prior to TEARDOWN of TTS

### DIFF
--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -660,6 +660,8 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 	}
 	while (running);
 
+	speech_channel_stop(mrcpsynth_session.schannel);
+
 	return mrcpsynth_exit(chan, &mrcpsynth_session, status);
 }
 


### PR DESCRIPTION
Resolves [DE4965 [UniMRCP] Resolve v1.3.0 Error after hanging up on TTS](https://rally1.rallydev.com/#/8108440228d/detail/defect/55087295387) for users interacting with a NeoSpeech MRCPv1 TTS server.

Related
- cloudvox/ansible#318
- cloudvox/stockyard#17
- cloudvox/asterisk-unimrcp#2
