### PR TITLE
Fix: Move ANNOUNCE:STOP to handle hangups

### DIFF
--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -626,7 +626,6 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		ms = ast_waitfor(chan, 100);
 		if (ms < 0) {
 			ast_log(LOG_DEBUG, "(%s) Hangup detected\n", name);
-			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
 			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}
@@ -634,7 +633,6 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		f = ast_read(chan);
 		if (!f) {
 			ast_log(LOG_DEBUG, "(%s) Null frame == hangup() detected\n", name);
-			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
 			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}

--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -626,12 +626,16 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		ms = ast_waitfor(chan, 100);
 		if (ms < 0) {
 			ast_log(LOG_DEBUG, "(%s) Hangup detected\n", name);
+			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
+			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}
 
 		f = ast_read(chan);
 		if (!f) {
 			ast_log(LOG_DEBUG, "(%s) Null frame == hangup() detected\n", name);
+			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
+			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}
 
@@ -659,8 +663,6 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		}
 	}
 	while (running);
-
-	speech_channel_stop(mrcpsynth_session.schannel);
 
 	return mrcpsynth_exit(chan, &mrcpsynth_session, status);
 }


### PR DESCRIPTION
As a follow-up to #1, it turns out that the fix was correct, but was handling the wrong use case of a clean finish of a TTS prompt.

Instead, the enclosed change will announce a STOP when interrupting or hanging up on a TTS prompt.

Related
- cloudvox/ansible#318
- cloudvox/stockyard#17
- cloudvox/asterisk-unimrcp#1
