### PR TITLE
DE5202 UniMRCP TTS teardown fix for SynthAndRecog()

### DIFF
--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1696,6 +1696,7 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 		f = ast_read(chan);
 		if (!f) {
 			ast_log(LOG_DEBUG, "(%s) Null frame. Hangup detected\n", recog_name);
+			speech_channel_stop(sar_session.synth_channel);
 			status = SPEECH_CHANNEL_STATUS_INTERRUPTED;
 			break;
 		}

--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1536,6 +1536,7 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 					f = ast_read(chan);
 					if (!f) {
 						ast_log(LOG_DEBUG, "(%s) ast_waitstream failed on %s, channel read is a null frame. Hangup detected\n", recog_name, ast_channel_name(chan));
+						speech_channel_stop(sar_session.synth_channel);
 						return synthandrecog_exit(chan, &sar_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 					}
 					ast_frfree(f);
@@ -1550,12 +1551,14 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 				ms = ast_waitfor(chan, 100);
 				if (ms < 0) {
 					ast_log(LOG_DEBUG, "(%s) Hangup detected\n", recog_name);
+					speech_channel_stop(sar_session.synth_channel);
 					return synthandrecog_exit(chan, &sar_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 				}
 
 				f = ast_read(chan);
 				if (!f) {
 					ast_log(LOG_DEBUG, "(%s) Null frame. Hangup detected\n", recog_name);
+					speech_channel_stop(sar_session.synth_channel);
 					return synthandrecog_exit(chan, &sar_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 				}
 


### PR DESCRIPTION
[[UniMRCP] Benign delay and error after hangup on ASR+TTS prompt](https://rally1.rallydev.com/#/8108440228d/detail/defect/59072749311)

Resolves delay and "Cancel RTSP" error in the asterisk logs when hanging up on TTS during an ASR-enabled prompt.
