### PR TITLE
DE5202: Always stop TTS

### DIFF
--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -626,16 +626,12 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		ms = ast_waitfor(chan, 100);
 		if (ms < 0) {
 			ast_log(LOG_DEBUG, "(%s) Hangup detected\n", name);
-			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
-			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}
 
 		f = ast_read(chan);
 		if (!f) {
 			ast_log(LOG_DEBUG, "(%s) Null frame == hangup() detected\n", name);
-			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
-			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}
 
@@ -663,6 +659,8 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		}
 	}
 	while (running);
+
+	speech_channel_stop(mrcpsynth_session.schannel);
 
 	return mrcpsynth_exit(chan, &mrcpsynth_session, status);
 }

--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -660,8 +660,6 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 	}
 	while (running);
 
-	speech_channel_stop(mrcpsynth_session.schannel);
-
 	return mrcpsynth_exit(chan, &mrcpsynth_session, status);
 }
 

--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -626,6 +626,7 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		ms = ast_waitfor(chan, 100);
 		if (ms < 0) {
 			ast_log(LOG_DEBUG, "(%s) Hangup detected\n", name);
+			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
 			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}
@@ -633,6 +634,7 @@ static int app_synth_exec(struct ast_channel *chan, ast_app_data data)
 		f = ast_read(chan);
 		if (!f) {
 			ast_log(LOG_DEBUG, "(%s) Null frame == hangup() detected\n", name);
+			ast_log(LOG_DEBUG, "(%s) Announcing STOP\n", mrcpsynth_session.schannel->name);
 			speech_channel_stop(mrcpsynth_session.schannel);
 			return mrcpsynth_exit(chan, &mrcpsynth_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
 		}

--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -474,8 +474,10 @@ static int mrcpsynth_exit(struct ast_channel *chan, mrcpsynth_session_t *mrcpsyn
 		if (mrcpsynth_session->writeformat)
 			ast_channel_set_writeformat(chan, mrcpsynth_session->writeformat);
 
-		if (mrcpsynth_session->schannel)
+		if (mrcpsynth_session->schannel) {
+			speech_channel_stop(mrcpsynth_session->schannel);
 			speech_channel_destroy(mrcpsynth_session->schannel);
+		}
 
 		if (mrcpsynth_session->pool)
 			apr_pool_destroy(mrcpsynth_session->pool);

--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1283,8 +1283,10 @@ static int synthandrecog_exit(struct ast_channel *chan, sar_session_t *sar_sessi
 		if (sar_session->readformat)
 			ast_channel_set_readformat(chan, sar_session->readformat);
 
-		if (sar_session->synth_channel)
+		if (sar_session->synth_channel) {
+			speech_channel_stop(sar_session->synth_channel);
 			speech_channel_destroy(sar_session->synth_channel);
+		}
 
 		if (sar_session->recog_channel) {
 			const char *session_id = speech_channel_get_id(sar_session->recog_channel);


### PR DESCRIPTION
This is the _lazy_ but hopefully comprehensive approach to ensuring that the TTS channel is cleanly and fully stopped before sending a TEARDOWN.

I say "lazy", because this approach will inevitably cause `speech_channel_stop()` to be invoked twice in some cases.  However, this should be fine, because [the method will exit much like a no-op if synth is not active, such as if the method has already been called](https://github.com/sfgeorge/asterisk-unimrcp/blob/feature/DE5202-unimrcp-tts-always-stop-fix/app-unimrcp/speech_channel.c#L562).
