### PR TITLE
DTPORTAL-16694 Fix hanging bargeable audio in SynthAndRecog()

### DIFF
--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1670,6 +1670,7 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 #if AST_VERSION_AT_LEAST(11,0,0)
 					if (ast_channel_streamid(chan) == -1 && ast_channel_timingfunc(chan) == NULL) {
 						ast_stopstream(chan);
+						end_of_prompt = 1;
 						sar_session.filestream = NULL;
 					}
 #else

--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1670,6 +1670,7 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 #if AST_VERSION_AT_LEAST(11,0,0)
 					if (ast_channel_streamid(chan) == -1 && ast_channel_timingfunc(chan) == NULL) {
 						ast_stopstream(chan);
+						ast_log(LOG_DEBUG, "(%s) File is over\n", recog_name);
 						end_of_prompt = 1;
 						sar_session.filestream = NULL;
 					}


### PR DESCRIPTION
## Issue Summary

When invoking SynthAndRecog() under the following circumstances:
* bargein enabled
* At least one audio prompt
* Asterisk version >= 11

Then the following problems occur:
1. No audio/TTS is played after the 1st audio file is played (because it does not track that the 1st audio file is finished).
2. If the caller is muted, then the prompt hangs indefinitely (since START-INPUT-TIMERS only begins after all audio files are finished).

## Cause

This issue seems to stem from b2494545bf4 in which we added a specific fix for Asterisk >= 11.  When we added that pre-processor logic branch, we should have preserved the setting of `end_of_prompt = 1;`.

## Resolution

Ensures that `end_of_prompt = 1;` is invoked at the end of an audio file, regardless of Asterisk version.