### PR TITLE
DTPORTAL-16883 Always STOP barged TTS

### DIFF
--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -458,8 +458,10 @@ static int mrcpsynth_exit(struct ast_channel *chan, mrcpsynth_session_t *mrcpsyn
 		if (mrcpsynth_session->rawwriteformat)
 			ast_channel_set_rawwriteformat(chan, mrcpsynth_session->rawwriteformat);
 
-		if (mrcpsynth_session->schannel)
+		if (mrcpsynth_session->schannel) {
+			speech_channel_stop(mrcpsynth_session->schannel);
 			speech_channel_destroy(mrcpsynth_session->schannel);
+		}
 
 		if (mrcpsynth_session->pool)
 			apr_pool_destroy(mrcpsynth_session->pool);

--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1289,8 +1289,10 @@ static int synthandrecog_exit(struct ast_channel *chan, sar_session_t *sar_sessi
 		if (sar_session->rawreadformat)
 			ast_channel_set_rawreadformat(chan, sar_session->rawreadformat);
 
-		if (sar_session->synth_channel)
+		if (sar_session->synth_channel) {
+			speech_channel_stop(sar_session->synth_channel);
 			speech_channel_destroy(sar_session->synth_channel);
+		}
 
 		if (sar_session->recog_channel) {
 			if (sar_session->recog_channel->session_id)


### PR DESCRIPTION
Ensure that NeoSpeech TTS completely shuts down a TTS port by sending a [MRCP STOP](https://tools.ietf.org/html/rfc4463#section-7.9) prior to the [RTSP TEARDOWN](https://tools.ietf.org/html/rfc2326#page-37).

----

Brings PR #4 to the modern age.

This is the _lazy_ but hopefully comprehensive approach to ensuring that the TTS channel is cleanly and fully stopped before sending a TEARDOWN.

I say "lazy", because this approach will inevitably cause `speech_channel_stop()` to be invoked twice in some cases.  However, this should be fine, because [the method will exit much like a no-op if synth is not active, such as if the method has already been called](https://github.com/sfgeorge/asterisk-unimrcp/blob/DTPORTAL-16883-always-STOP-barged-TTS/app-unimrcp/speech_channel.c#L554).
